### PR TITLE
parameters are persistent

### DIFF
--- a/examples/LookAheadCompressor/Source/PluginProcessor.cpp
+++ b/examples/LookAheadCompressor/Source/PluginProcessor.cpp
@@ -231,15 +231,15 @@ AudioProcessorEditor* LookAheadCompressorAudioProcessor::createEditor()
 //==============================================================================
 void LookAheadCompressorAudioProcessor::getStateInformation (MemoryBlock& destData)
 {
-    // You should use this method to store your parameters in the memory block.
-    // You could do that either as raw data, or use the XML or ValueTree classes
-    // as intermediaries to make it easy to save and load complex data.
+    const auto str = parameters.copyState().toXmlString().toStdString();
+    destData.setSize(str.size());
+    destData.copyFrom(str.data(), 0, str.size());
 }
 
 void LookAheadCompressorAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
-    // You should use this method to restore your parameters from this memory block,
-    // whose contents will have been created by the getStateInformation() call.
+    String str{reinterpret_cast<const char *>(data), (size_t)sizeInBytes};
+    parameters.replaceState(ValueTree::fromXml(str));
 }
 
 //==============================================================================


### PR DESCRIPTION
Thanks @DanielRudrich for the informative and useful code!
It's quite annoying to have to reset manually the parameters each time one closes or reopens the UI when using the VST3 plugin.
This PR is one way of doing it. Probably not bullet proof, but already an improvement.